### PR TITLE
Corrigindo problema ao rodar script de build

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,9 @@
+const shell = require('shelljs')
+
+const successMessage = 'The build folder is ready to be deployed.'
+const result = shell.exec('timeout react-scripts build -t 1m')
+
+if (result.stdout.includes(successMessage))
+  process.exit(0)
+else
+  process.exit(result.code)

--- a/package.json
+++ b/package.json
@@ -17,8 +17,11 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "timeout react-scripts build -t 15s",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
+  },
+  "devDependencies": {
+    "timeout-cli": "^0.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "timeout react-scripts build -t 1m ; echo 'Done'",
+    "build": "node build.js",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
   "devDependencies": {
+    "shelljs": "^0.7.8",
     "timeout-cli": "^0.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "timeout react-scripts build -t 15s",
+    "build": "timeout react-scripts build -t 1m ; echo 'Done'",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
O script de build do `custom-react-scripts` não finaliza na minha máquina e nem no Netlify, que estou usando para fazer deploy.
Essa correção permite estabelecer um **timeout** para finalizar a execução do script e permitir fazer o deploy.
Quando a issue [101](https://github.com/kitze/custom-react-scripts/issues/101) do `custom-react-scripts` for resolvida poderemos remover essa alteração.